### PR TITLE
correction of this bundle for symfony 2.8 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class AppKernel extends Kernel
         $bundles = array(
             // ...
 
-            new OpenLdapObject\Bundle\LdapObjectBundle\Toshy62LdapObjectBundle(),
+            new OpenLdapObject\Bundle\LdapObjectBundle\OpenLdapObjectLdapObjectBundle(),
         );
 
         // ...

--- a/README.md
+++ b/README.md
@@ -17,7 +17,39 @@ This command requires you to have Composer installed globally, as explained
 in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
 of the Composer documentation.
 
-Step 2: Enable the Bundle
+Or add the bundle in your `composer.json` and launch this command `composer update`
+```
+...
+    "require" : {
+        ...
+        "openldapobject/ldapobjectbundle": "~1.0",
+        ...
+    },
+...
+```
+
+Step 2: Configuration
+---------------------
+Add configuration keys in the `app/config/parameters.yml` and `app/config/parameters.yml.dist` and configure for your openldap :
+```
+    ldap_hostname: ldap-test.univ.fr
+    ldap_base_dn: 'dc=univ,dc=fr'
+    ldap_dn: 'cn=login,ou=ldapusers,dc=univ,dc=fr'
+    ldap_password: 'password'
+```
+
+Add configuration keys for the bundle in `app/config/config.yml`
+```
+# Ldap
+open_ldap_object_ldap_object:
+    host:     "%ldap_hostname%"
+    dn:       "%ldap_dn%"
+    password: "%ldap_password%"
+    base_dn:  "%ldap_base_dn%"
+```
+
+
+Step 3: Enable the Bundle
 -------------------------
 
 Then, enable the bundle by adding the following line in the `app/AppKernel.php`

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": ">=5.4.0",
 	"symfony/framework-bundle": "~2.3",
-        "openldapobject/openldapobject": "~1.0,>=1.1"
+        "openldapobject/openldapobject": "~1.0,>=1.1",
+	"symfony/symfony": ">=2.8.*"
     }
 }

--- a/lib/OpenLdapObject/Bundle/LdapObjectBundle/LdapWrapper.php
+++ b/lib/OpenLdapObject/Bundle/LdapObjectBundle/LdapWrapper.php
@@ -2,6 +2,8 @@
 
 namespace OpenLdapObject\Bundle\LdapObjectBundle;
 
+use OpenLdapObject\LdapClient\Connection;
+use OpenLdapObject\Manager\EntityManager;
 
 class LdapWrapper {
     /**
@@ -9,7 +11,25 @@ class LdapWrapper {
      */
     private $em;
 
-    public function __construct() {
+    public function __construct($hostname = false, $port = false, $base_dn = false, $dn = false, $password = false) {
+        
+        if (($hostname != false) && ($port != false) && ($base_dn != false) && ($dn != false) && ($password != false)) {
+            if (($port == "") || ($port == false) || (empty($port)) || (is_null($port))) {
+                $port = 389;
+            }
+            $connect = new Connection($hostname, $port);
+            if (!is_null($dn) && !is_null($password)) {
+                $connect->identify($dn, $password);
+            }
+
+            $client = $connect->connect();
+            $client->setBaseDn($base_dn);
+            try {
+                \OpenLdapObject\Manager\EntityManager::addEntityManager('default', $client, true);
+            } catch(Exception $e) {
+                // Nothing
+            }
+        }
         $this->em = \OpenLdapObject\Manager\EntityManager::getEntityManager();
     }
 

--- a/lib/OpenLdapObject/Bundle/LdapObjectBundle/OpenLdapObjectLdapObjectBundle.php
+++ b/lib/OpenLdapObject/Bundle/LdapObjectBundle/OpenLdapObjectLdapObjectBundle.php
@@ -3,26 +3,7 @@
 namespace OpenLdapObject\Bundle\LdapObjectBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use OpenLdapObject\LdapClient\Connection;
-use OpenLdapObject\Manager\EntityManager;
 
 class OpenLdapObjectLdapObjectBundle extends Bundle {
-    public function boot() {
-        parent::boot();
-
-        if(!is_null($this->container->getParameter('ldap_object.host'))) {
-            $connect = new Connection($this->container->getParameter('ldap_object.host'), $this->container->getParameter('ldap_object.port'));
-            if(!is_null($this->container->getParameter('ldap_object.dn')) && !is_null($this->container->getParameter('ldap_object.password'))) {
-                $connect->identify($this->container->getParameter('ldap_object.dn'), $this->container->getParameter('ldap_object.password'));
-            }
-
-            $client = $connect->connect();
-            $client->setBaseDn($this->container->getParameter('ldap_object.base_dn'));
-            try {
-                EntityManager::addEntityManager('default', $client, true);
-            } catch(Exception $e) {
-                // Nothing
-            }
-        }
-    }
+    
 }

--- a/lib/OpenLdapObject/Bundle/LdapObjectBundle/Resources/config/services.yml
+++ b/lib/OpenLdapObject/Bundle/LdapObjectBundle/Resources/config/services.yml
@@ -1,4 +1,4 @@
 services:
     ldap_object.manager:
         class: OpenLdapObject\Bundle\LdapObjectBundle\LdapWrapper
-        arguments: []
+        arguments: [%ldap_object.host%, %ldap_object.port%, %ldap_object.base_dn%, %ldap_object.dn%, %ldap_object.password%]


### PR DESCRIPTION
Hello,

When i run "composer update" or "php app/console cache:clear" i got this error:

  [InvalidArgumentException]            
  The "default" manager is not defined

It happens because the function boots in the bundle is not supported in Symfony 2.8 (or later?).

In order to preserv the correct execution of this bundle, i propose this pull requests and this corrections :)